### PR TITLE
Allow bs_get_profile() to handle more than 25 users

### DIFF
--- a/R/actor_profile.R
+++ b/R/actor_profile.R
@@ -36,7 +36,7 @@ bs_get_profile <- function(actors,
   req <- httr2::request(base_url)
 
   .get_profile_mult <- function(actor, basereq=req) {
-    actors_resp <- basereq |>
+    basereq |>
       httr2::req_auth_bearer_token(token = auth$accessJwt) |>
       httr2::req_url_query(actors=actor, .multi = "explode") |>
       httr2::req_perform() |>


### PR DESCRIPTION
## Overview
`bs_get_profile()` currently rejects attempts to request profile data of more than 25 users at once.

This PR adds that functionality by splitting the requested vector of user names into sub-vectors of 25 entries (max) each. It then performs one request per subvector and unpacks the resultant nested list, ready to feed into the final processing code from the original function.

## Notes

- `getProfiles` does not support cursor-based traversal, hence why this implementation cannot use the `repeat_request()` function used elsewhere throughout `bskyr`.
- Currently this does not provide a progress bar (though it could be worth providing one for requests above a certain size). Requesting thousands of profiles can take minutes to complete.
- Currently there is no rate limiting of multiple requests, however this could be achieved using `httr2::req_throttle()` if desired.
- `rlang::inject()` method of adding multiple queries has been replaced here with the builtin `.multi` argument of `httr2::req_url_query()`, which is designed to handle these requests natively.
- Currently, when clean=TRUE, this function spits out a large number of messages to the console when executed, as was the case with the previous version. This is due to columns being repeated with the same name when expanding out to create a tibble of the results (I think this is in `proc()`). Whilst this could be suppressed with something like `suppressMessages()`, it is probably better to investigate this at the `proc()` level instead.