### PR TITLE
Update embed type

### DIFF
--- a/R/embed_external.R
+++ b/R/embed_external.R
@@ -94,7 +94,7 @@ bs_new_embed_external <- function(uri, title, description, thumb,
 
 
   rec <- list(
-    `$type` = 'app.bsky.embed.external',
+    `$type` = 'app.bsky.embed.external#external',
     # external = list(
     uri = uri,
     title = title,

--- a/R/record_post.R
+++ b/R/record_post.R
@@ -263,12 +263,12 @@ bs_post <- function(text, images, images_alt,
     # 1. list of embeds manually provided
     if (is.list(embed)) {
       card <- list(
-        '$type' = 'app.bsky.embed.external',
+        '$type' = 'app.bsky.embed.external#external',
         external = embed
       )
     } else if (is.character(embed) && is_online_link(embed)) {
       card <- list(
-        '$type' = 'app.bsky.embed.external',
+        '$type' = 'app.bsky.embed.external#external',
         external = bs_new_embed_external(uri = embed, auth = auth)
       )
     } else if (isTRUE(embed)) {
@@ -276,7 +276,7 @@ bs_post <- function(text, images, images_alt,
       tenor_gif <- parse_tenor_gif(text, user = user, pass = pass, auth = auth)
       if (!is.null(tenor_gif)) {
         card <- list(
-          '$type' = 'app.bsky.embed.external',
+          '$type' = 'app.bsky.embed.external#external',
           external = tenor_gif
         )
       } else {
@@ -284,7 +284,7 @@ bs_post <- function(text, images, images_alt,
         link_card <- parse_first_link(text, auth = auth)
         if (!is.null(link_card)) {
           card <- list(
-            '$type' = 'app.bsky.embed.external',
+            '$type' = 'app.bsky.embed.external#external',
             external = link_card
           )
         }

--- a/R/record_post.R
+++ b/R/record_post.R
@@ -263,12 +263,12 @@ bs_post <- function(text, images, images_alt,
     # 1. list of embeds manually provided
     if (is.list(embed)) {
       card <- list(
-        '$type' = 'app.bsky.embed.external#external',
+        '$type' = 'app.bsky.embed.external',
         external = embed
       )
     } else if (is.character(embed) && is_online_link(embed)) {
       card <- list(
-        '$type' = 'app.bsky.embed.external#external',
+        '$type' = 'app.bsky.embed.external',
         external = bs_new_embed_external(uri = embed, auth = auth)
       )
     } else if (isTRUE(embed)) {
@@ -276,7 +276,7 @@ bs_post <- function(text, images, images_alt,
       tenor_gif <- parse_tenor_gif(text, user = user, pass = pass, auth = auth)
       if (!is.null(tenor_gif)) {
         card <- list(
-          '$type' = 'app.bsky.embed.external#external',
+          '$type' = 'app.bsky.embed.external',
           external = tenor_gif
         )
       } else {
@@ -284,7 +284,7 @@ bs_post <- function(text, images, images_alt,
         link_card <- parse_first_link(text, auth = auth)
         if (!is.null(link_card)) {
           card <- list(
-            '$type' = 'app.bsky.embed.external#external',
+            '$type' = 'app.bsky.embed.external',
             external = link_card
           )
         }


### PR DESCRIPTION
Problem: Posting text containing links did throw an error (with embed set to True). The API reported: 'Invalid app.bsky.feed.post record: Expected "app.bsky.embed.external#external" (got "app.bsky.embed.external") at $.record.embed.external.'

Fix: Added #external to the end of the embed type to aovid this error

Many thanks for your work with this very helpful package! 